### PR TITLE
Two data sources

### DIFF
--- a/caffe/include/caffe/layers/molgrid_data_layer.hpp
+++ b/caffe/include/caffe/layers/molgrid_data_layer.hpp
@@ -235,6 +235,11 @@ class MolGridDataLayer : public BaseDataLayer<Dtype> {
 
   struct examples
   {
+    bool store_all;
+    bool store_actives_decoys;
+    bool store_pairs;
+    int count;
+
     string root_folder;
 
     vector<example> all;
@@ -247,8 +252,14 @@ class MolGridDataLayer : public BaseDataLayer<Dtype> {
     int decoys_index;
     bool shuffle_on_wrap; //TODO this doesn't apply to pairs for now
 
-    examples(): all_index(0), actives_index(0), decoys_index(0), shuffle_on_wrap(false) {}
+    examples(): all_index(0), actives_index(0), decoys_index(0) {}
+    examples(bool all, bool actives_decoys, bool pairs):
+        all_index(0), actives_index(0), decoys_index(0), store_all(all),
+        store_actives_decoys(actives_decoys), store_pairs(pairs) {}
+
+    void add(const example& ex);
     void shuffle_();
+
     void next(example& ex);
     void next_active(example& ex);
     void next_decoy(example& ex);

--- a/caffe/include/caffe/layers/molgrid_data_layer.hpp
+++ b/caffe/include/caffe/layers/molgrid_data_layer.hpp
@@ -252,14 +252,17 @@ class MolGridDataLayer : public BaseDataLayer<Dtype> {
     int decoys_index;
     bool shuffle_on_wrap; //TODO this doesn't apply to pairs for now
 
-    examples(): all_index(0), actives_index(0), decoys_index(0) {}
-    examples(bool all, bool actives_decoys, bool pairs):
-        all_index(0), actives_index(0), decoys_index(0), store_all(all),
-        store_actives_decoys(actives_decoys), store_pairs(pairs) {}
+    examples():
+        store_all(true), store_actives_decoys(true), store_pairs(true), count(0),
+        all_index(0), actives_index(0), decoys_index(0), shuffle_on_wrap(false) {}
+
+    examples(bool all, bool actives_decoys, bool pairs, bool shuffle, string& root):
+        store_all(all), store_actives_decoys(actives_decoys), store_pairs(pairs), count(0),
+        all_index(0), actives_index(0), decoys_index(0), shuffle_on_wrap(shuffle),
+        root_folder(root) {}
 
     void add(const example& ex);
     void shuffle_();
-
     void next(example& ex);
     void next_active(example& ex);
     void next_decoy(example& ex);

--- a/caffe/include/caffe/layers/molgrid_data_layer.hpp
+++ b/caffe/include/caffe/layers/molgrid_data_layer.hpp
@@ -248,7 +248,6 @@ class MolGridDataLayer : public BaseDataLayer<Dtype> {
     bool shuffle_on_wrap; //TODO this doesn't apply to pairs for now
 
     examples(): all_index(0), actives_index(0), decoys_index(0), shuffle_on_wrap(false) {}
-    void add(const example& ex);
     void shuffle_();
     void next(example& ex);
     void next_active(example& ex);

--- a/caffe/src/caffe/layers/molgrid_data_layer.cpp
+++ b/caffe/src/caffe/layers/molgrid_data_layer.cpp
@@ -279,6 +279,8 @@ void MolGridDataLayer<Dtype>::DataLayerSetUp(const vector<Blob<Dtype>*>& bottom,
   //keep track of atoms and transformations for each example in batch
   batch_transform.resize(batch_size);
 
+  CHECK_LE(inmem + paired + balanced, 1) << "Only one of inmemory, paired, and balanced can be set";
+
   if(!inmem)
   {
     const string& source = this->layer_param_.molgrid_data_param().source();

--- a/caffe/src/caffe/layers/molgrid_data_layer.cpp
+++ b/caffe/src/caffe/layers/molgrid_data_layer.cpp
@@ -316,9 +316,7 @@ void MolGridDataLayer<Dtype>::DataLayerSetUp(const vector<Blob<Dtype>*>& bottom,
     CHECK((bool)infile) << "Could not open " << source;
 
     bool all = !(balanced || paired);
-    data = examples(all, balanced, paired);
-    data.root_folder = root_folder;
-    data.shuffle_on_wrap = shuffle;
+    data = examples(all, balanced, paired, shuffle, root_folder);
 
     string line;
     while (getline(infile, line))
@@ -335,9 +333,7 @@ void MolGridDataLayer<Dtype>::DataLayerSetUp(const vector<Blob<Dtype>*>& bottom,
       std::ifstream infile(source2.c_str());
       CHECK((bool)infile) << "Could not open " << source2;
 
-      data2 = examples(all, balanced, paired);
-      data2.root_folder = root_folder2;
-      data2.shuffle_on_wrap = shuffle;
+      data2 = examples(all, balanced, paired, shuffle, root_folder2);
 
       while (getline(infile, line))
       {


### PR DESCRIPTION
Save memory in MolGridDataLayer by not storing examples more than once. Check paired and balanced params to determine where each example should be stored, rather than storing redundant copies.