### PR TITLE
bug fix for outputting atom gradient in .xyz format

### DIFF
--- a/gninasrc/lib/cnn_scorer.cpp
+++ b/gninasrc/lib/cnn_scorer.cpp
@@ -25,7 +25,7 @@ using namespace std;
 CNNScorer::CNNScorer(const cnn_options& cnnopts, const vec& center,
         const model& m) :
         rotations(cnnopts.cnn_rotations), seed(cnnopts.seed),
-        outputdx(cnnopts.outputdx), outputxyz(cnnopts.outputxyz),
+        outputdx(cnnopts.outputdx), outputxyz(cnnopts.outputxyz), xyzprefix(cnnopts.xyzprefix),
         mtx(new boost::mutex) {
 
     if (cnnopts.cnn_scoring)
@@ -278,8 +278,12 @@ float CNNScorer::score(model& m, bool compute_gradient, float& aff, bool silent)
 
 	if (outputdx) {
 		outputDX(m.get_name());
-		const string& ligname = m.get_name() + "_lig";
-		const string& recname = m.get_name() + "_rec";
+	}
+
+	if (outputxyz) {
+		const string& ligname = xyzprefix + "_lig.xyz";
+		const string& recname = xyzprefix + "_rec.xyz";
+
 		mgrid->getLigandGradient(0, gradient);
 		mgrid->getLigandAtoms(0, atoms);
 		mgrid->getLigandChannels(0, channels);

--- a/gninasrc/lib/cnn_scorer.h
+++ b/gninasrc/lib/cnn_scorer.h
@@ -28,6 +28,7 @@ struct cnn_options {
     bool cnn_scoring; //if true, do cnn_scoring of final pose
     bool outputdx;
     bool outputxyz;
+    std::string xyzprefix;
     unsigned seed; //random seed
 
     cnn_options(): resolution(0.5), cnn_rotations(0), cnn_scoring(false), outputdx(false), outputxyz(false), seed(0) {}
@@ -44,17 +45,18 @@ class CNNScorer {
     unsigned seed;
     bool outputdx;
     bool outputxyz;
+    std::string xyzprefix;
 
     caffe::shared_ptr<boost::mutex> mtx; //todo, enable parallel scoring
 
-	//scratch vectors to avoid memory reallocation
-	vector<float3> gradient;
+    //scratch vectors to avoid memory reallocation
+    vector<float3> gradient;
     vector<float4> atoms;
     vector<short> channels;
 
 public:
-	CNNScorer(): mgrid(NULL), rotations(0), outputdx(false), outputxyz(false), mtx(new boost::mutex) {}
-	virtual ~CNNScorer() {}
+    CNNScorer(): mgrid(NULL), rotations(0), outputdx(false), outputxyz(false), mtx(new boost::mutex) {}
+    virtual ~CNNScorer() {}
 
     CNNScorer(const cnn_options& cnnopts, const vec& center, const model& m);
 

--- a/gninasrc/main/main.cpp
+++ b/gninasrc/main/main.cpp
@@ -1211,7 +1211,9 @@ Thank you!\n";
 		("cnn_outputdx", bool_switch(&cnnopts.outputdx)->default_value(false),
 		               "Dump .dx files of atom grid gradient.")
 		("cnn_outputxyz", bool_switch(&cnnopts.outputxyz)->default_value(false),
-		               "Dump .xyz files of atom gradient.");
+		               "Dump .xyz files of atom gradient.")
+		("cnn_xyzprefix", value<std::string>(&cnnopts.xyzprefix),
+		               "Prefix for atom gradient .xyz files");
 
 		options_description misc("Misc (optional)");
 		misc.add_options()


### PR DESCRIPTION
A previous commit broke the --cnn_outputxyz option. This fixes that and also adds more clarity and flexibility for naming the .xyz files that are produced.