### PR TITLE
Fix so copying a model does not copy (and subsequently attempt to free)

### DIFF
--- a/gninasrc/lib/bfgs.cu
+++ b/gninasrc/lib/bfgs.cu
@@ -217,8 +217,9 @@ void bfgs_gpu(quasi_newton_aux_gpu f,
 		    minus_mat_vec_product(h, g, p);
             // f1 is the returned energy for the next iteration of eval_deriv_gpu
 		    f1 = 0;
-            //do we even care about the fast_line_search?
-		    assert(params.type == minimization_params::BFGSAccurateLineSearch);
+            //TODO: FastLineSearch is implemented in develop, until then just
+            //always do accurage here
+		    // assert(params.type == minimization_params::BFGSAccurateLineSearch);
         }
         __syncthreads();
 		alpha = accurate_line_search_gpu(f, n, x, g, f0,

--- a/gninasrc/lib/model.h
+++ b/gninasrc/lib/model.h
@@ -42,6 +42,7 @@ typedef std::vector<interacting_pair> interacting_pairs;
 
 typedef std::pair<std::string, boost::optional<sz> > parsed_line;
 typedef std::vector<parsed_line> pdbqtcontext;
+struct parallel_mc_task;
 void test_eval_intra();
 
 struct gpu_data {
@@ -93,6 +94,10 @@ struct gpu_data {
 	void copy_from_gpu(model& m);
 
     size_t node_idx_cpu2gpu(size_t cpu_idx) const;
+  private:
+    gpu_data(const gpu_data&) = default;
+    friend struct quasi_newton_aux_gpu;
+    friend parallel_mc_task;
 };
 
 // dkoes - as an alternative to pdbqt, this stores information
@@ -241,6 +246,15 @@ struct pdbqt_initializer; // forward declaration - only declared in parse_pdbqt.
 struct model_test;
 
 struct model {
+
+  model(const model& m) : tree_width(m.tree_width), coords(m.coords), 
+  ligands(m.ligands), minus_forces(m.minus_forces), 
+  m_num_movable_atoms(m.m_num_movable_atoms), atoms(m.atoms), 
+  grid_atoms(m.grid_atoms), other_pairs(m.other_pairs), 
+  hydrogens_stripped(m.hydrogens_stripped), 
+  internal_coords(m.internal_coords), flex(m.flex), 
+  flex_context(m.flex_context), name(m.name), pose_num(m.pose_num) {}
+
 	void append(const model& m);
 	void strip_hydrogens();
 


### PR DESCRIPTION
its gpu_data.