### PR TITLE
extend pycaffe solver API for GAN training

### DIFF
--- a/caffe/include/caffe/solver.hpp
+++ b/caffe/include/caffe/solver.hpp
@@ -73,6 +73,7 @@ class Solver {
     return test_nets_;
   }
   int iter() const { return iter_; }
+  void increment_iter() { iter_++; }
 
   // Invoked at specific points during an iteration
   class Callback {
@@ -103,10 +104,10 @@ class Solver {
   }
 
   void TestAll();
+  virtual void ApplyUpdate() = 0;
 
  protected:
   // Make and apply the update value for the current iteration.
-  virtual void ApplyUpdate() = 0;
   string SnapshotFilename(const string extension);
   string SnapshotToBinaryProto();
   string SnapshotToHDF5();

--- a/caffe/python/caffe/_caffe.cpp
+++ b/caffe/python/caffe/_caffe.cpp
@@ -457,6 +457,8 @@ BOOST_PYTHON_MODULE(_caffe) {
     .def("solve", static_cast<void (Solver<Dtype>::*)(const char*)>(
           &Solver<Dtype>::Solve), SolveOverloads())
     .def("step", &Solver<Dtype>::Step)
+    .def("apply_update", &Solver<Dtype>::ApplyUpdate)
+    .def("increment_iter", &Solver<Dtype>::increment_iter)
     .def("restore", &Solver<Dtype>::Restore)
     .def("testall", &Solver<Dtype>::TestAll)
     .def("get_base_lr", &Solver<Dtype>::get_base_lr)

--- a/caffe/python/caffe/draw.py
+++ b/caffe/python/caffe/draw.py
@@ -91,11 +91,11 @@ def get_layer_label(layer, rankdir):
                       separator,
                       layer.type,
                       separator,
-                      layer.convolution_param.kernel_size[0] if len(layer.convolution_param.kernel_size._values) else 1,
+                      layer.convolution_param.kernel_size[0] if len(layer.convolution_param.kernel_size) else 1,
                       separator,
-                      layer.convolution_param.stride[0] if len(layer.convolution_param.stride._values) else 1,
+                      layer.convolution_param.stride[0] if len(layer.convolution_param.stride) else 1,
                       separator,
-                      layer.convolution_param.pad[0] if len(layer.convolution_param.pad._values) else 0)
+                      layer.convolution_param.pad[0] if len(layer.convolution_param.pad) else 0)
     elif layer.type == 'Pooling':
         pooling_types_dict = get_pooling_types_dict()
         node_label = '"%s%s(%s %s)%skernel size: %d%sstride: %d%spad: %d"' %\
@@ -104,11 +104,11 @@ def get_layer_label(layer, rankdir):
                       pooling_types_dict[layer.pooling_param.pool],
                       layer.type,
                       separator,
-                      layer.pooling_param.kernel_size[0] if len(layer.pooling_param.kernel_size._values) else 1,
+                      layer.pooling_param.kernel_size[0] if len(layer.pooling_param.kernel_size) else 1,
                       separator,
-                      layer.pooling_param.stride[0] if len(layer.pooling_param.stride._values) else 1,
+                      layer.pooling_param.stride[0] if len(layer.pooling_param.stride) else 1,
                       separator,
-                      layer.pooling_param.pad[0] if len(layer.pooling_param.pad._values) else 0)
+                      layer.pooling_param.pad[0] if len(layer.pooling_param.pad) else 0)
     else:
         node_label = '"%s%s(%s)"' % (layer.name, separator, layer.type)
     return node_label


### PR DESCRIPTION
This exposes more methods to the pycaffe Solver object which allow more control over training, for example to allow two-phase training necessary for GANs. There's also a bug fix to make the draw_net.py helper script work as intended.