### PR TITLE
Small fix that doesn't fix the problem

### DIFF
--- a/gninasrc/lib/bfgs.cu
+++ b/gninasrc/lib/bfgs.cu
@@ -244,6 +244,9 @@ void bfgs_gpu(quasi_newton_aux_gpu<infoT> f, conf_gpu x, conf_gpu x_orig,
   if (idx == 0) {
     f0 = f(x, g);
     f_orig = f0;
+    g_orig = g;
+    x_orig = x; 
+    p = g;
   }
   VINA_U_FOR(step, params.maxiters) {
     if (idx < g.n) {


### PR DESCRIPTION
A couple of conf and change objects weren't being updated after the first call to eval_deriv_gpu in bfgs. In the CPU version this is where they are _constructed_, but in the GPU version they are initially constructed on the host, prior to the main bfgs routine, so they need to be updated after the first eval_deriv_gpu call. 