### PR TITLE
makeflex readme

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -9,3 +9,5 @@ Usage:
 python makeflex.py RIGID.pdb FLEXIBLE.pdb OUT.pdb
 ```
 where `RIGID.pdb` contains the original receptor, `RIGID.pdb` contains the flexible side chains (output of flexible docking) and `OUT.pdb` is the output containing the full receptor with the flexible resiudes re-inserted.
+
+`makeflex.py` supports multiple models (`MODEL`/`ENDMDL`) in `FLEXIBLE.pdb`.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,11 @@
+# Scripts
+
+## MakeFlex
+
+The script `makeflex.py` can be used after flexible docking to build a full receptor. Given the original receptor and the flexible side chains obtained via flexible docking (with `smina` or `gnina`), the script builds the full receptor with the flexible residues re-inserted.
+
+Usage:
+```
+python makeflex.py RIGID.pdb FLEXIBLE.pdb OUT.pdb
+```
+where `RIGID.pdb` contains the original receptor, `RIGID.pdb` contains the flexible side chains (output of flexible docking) and `OUT.pdb` is the output containing the full receptor with the flexible resiudes re-inserted.

--- a/scripts/makeflex.py
+++ b/scripts/makeflex.py
@@ -69,6 +69,10 @@ for ci in range(flex.numCoordsets()):
                     )
                 else:
                     line = ""
+        elif line.startswith("END"):
+            line = ""
 
         out.write(line)
-out.write("ENDMDL\n")
+    
+    out.write("ENDMDL\n")
+out.write("END\n")


### PR DESCRIPTION
Added `README.md` for the `makeflex.py` script, and conformed to the following PDB format for multiple models:
```
MODEL
ENDMDL
MODEL
ENDMDL
END
```