### PR TITLE
resolve boost::thread ambiguity and update GetHvyDegree to GetHvyValence

### DIFF
--- a/gninasrc/gninaserver/MinimizationQuery.cpp
+++ b/gninasrc/gninaserver/MinimizationQuery.cpp
@@ -72,7 +72,7 @@ bool MinimizationQuery::finished() {
 //execute the query - set up the minimization threads and communication queue
 void MinimizationQuery::execute(bool block/*=false*/) {
   assert(minimizationSpawner == NULL);
-  minimizationSpawner = new thread(thread_startMinimization, this);
+  minimizationSpawner = new boost::thread(thread_startMinimization, this);
 
   if (block) minimizationSpawner->join();
 }
@@ -85,7 +85,7 @@ void MinimizationQuery::thread_startMinimization(MinimizationQuery *query) {
   timer::cpu_timer mintime;
 
   for (unsigned t = 0; t < query->minparm.nthreads; t++) {
-    minthreads.add_thread(new thread(thread_minimize, query));
+    minthreads.add_thread(new boost::thread(thread_minimize, query));
   }
   minthreads.join_all(); //block till all done
 

--- a/gninasrc/gninaserver/server.cpp
+++ b/gninasrc/gninaserver/server.cpp
@@ -24,7 +24,7 @@ cl::opt<unsigned> maxConcurrent("max-concurrent-requests",
     cl::init(16));
 cl::opt<unsigned> minimizationThreads("threads",
     cl::desc("number of threads to use for minimization"),
-    cl::init(max(1U, thread::hardware_concurrency() / 2)));
+    cl::init(max(1U, boost::thread::hardware_concurrency() / 2)));
 cl::opt<string> logfile("logfile", cl::desc("file for logging information"));
 
 typedef unordered_map<string, boost::shared_ptr<Command> > cmd_map;
@@ -49,7 +49,7 @@ static void process_request(stream_ptr s, cmd_map& cmap) {
 //periodically check for expired queries
 static void thread_purge_old_queries(QueryManager *qmgr) {
   while (true) {
-    this_thread::sleep(posix_time::time_duration(0, 3, 0, 0));
+    boost::this_thread::sleep(posix_time::time_duration(0, 3, 0, 0));
     unsigned npurged = qmgr->purgeOldQueries();
   }
 }
@@ -79,11 +79,11 @@ int main(int argc, char *argv[]) {
   cout << "Listening on port " << port << "\n";
 
   //start up cleanup thread
-  thread cleanup(thread_purge_old_queries, &queries);
+  boost::thread cleanup(thread_purge_old_queries, &queries);
   while (true) {
     stream_ptr s = stream_ptr(new tcp::iostream());
     a.accept(*s->rdbuf());
-    thread t(bind(process_request, s, commands));
+    boost::thread t(bind(process_request, s, commands));
   }
 
 }

--- a/gninasrc/lib/PDBQTUtilities.cpp
+++ b/gninasrc/lib/PDBQTUtilities.cpp
@@ -120,8 +120,8 @@ bool IsRotBond_PDBQT(OBBond * the_bond, unsigned desired_root)
       || the_bond->IsInRing()) {
     return false;
   }
-  if (((the_bond->GetBeginAtom())->GetHvyDegree() == 1)
-      || ((the_bond->GetEndAtom())->GetHvyDegree() == 1)) {
+  if (((the_bond->GetBeginAtom())->GetHvyValence() == 1)
+      || ((the_bond->GetEndAtom())->GetHvyValence() == 1)) {
     if (the_bond->GetBeginAtomIdx() == desired_root)
       return true;
     else


### PR DESCRIPTION
- References to thread were ambiguous when compiled with gcc 6.3.0, CUDA 10, Boost 1.67.0
- In latest Open Babel, OBAtom::GetHvyDegree is changed to GetHvyValence (https://github.com/dkoes/openbabel/blob/master/src/atom.cpp)