### PR TITLE
Insertion code support for makeflex.py

### DIFF
--- a/scripts/makeflex.py
+++ b/scripts/makeflex.py
@@ -86,7 +86,6 @@ for ci in range(flex.numCoordsets()):  # Loop over different MODELs (MODEL/ENDMD
                     resatoms = flex[chain].select("resnum %d and not name H" % resnum)
                     w = which[(chain, resnum)]
                     which[(chain, resnum)] += 1  # update to next index
-                    #print(resnum, aname, chain, [atom for atom in resatoms])
                     atom = resatoms[w]  # this is the atom to replace this line with
                     c = atom.getCoordsets(ci)
                     line = PDBLINE % (
@@ -101,7 +100,7 @@ for ci in range(flex.numCoordsets()):  # Loop over different MODELs (MODEL/ENDMD
                         atype,
                     )
                 else:
-                    # Remove H atoms
+                    # Remove non-backbone H atoms in flexible residue
                     line = ""
 
         elif line.startswith("END"):


### PR DESCRIPTION
Added insertion code support to the `makeflex.py` script.

To work, this needs the latest version of `smina` and a patched version of OpenBabel (see [PR #188](https://github.com/openbabel/openbabel/pull/1998)), providing fixes for insertion codes input/output.