### PR TITLE
Fix gradient visualisation in gninavis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,9 @@ python/caffe/proto/
 cmake_build
 .cmake_build
 
+# tests
+test/gnina/Testing/Temporary
+
 # Generated documentation
 docs/_site
 docs/_includes

--- a/caffe/src/caffe/layers/molgrid_data_layer.cpp
+++ b/caffe/src/caffe/layers/molgrid_data_layer.cpp
@@ -283,7 +283,7 @@ void MolGridDataLayer<Dtype>::getMappedLigandGradient(int batch_idx, unordered_m
 
   CoordinateSet& latoms = batch_info[batch_idx].transformed_lig_atoms;
   ManagedGrid<Dtype, 2>& grads = batch_info[batch_idx].lig_gradient;
-  CHECK_EQ(latoms.size(), grads.size());
+  CHECK_EQ(latoms.size(), grads.dimension(0));
   gradient.clear();
 
   for (unsigned i = 0, n = latoms.size(); i < n; ++i) {

--- a/gninasrc/lib/cnn_scorer.cpp
+++ b/gninasrc/lib/cnn_scorer.cpp
@@ -569,8 +569,23 @@ void CNNScorer::outputXYZ(const string& base, const vector<gfloat3>& atoms,
   ofstream out(base.c_str());
   out.precision(5);
 
-  out << atoms.size() << "\n\n";
+  // Count number of valid (>= 0) whichGrid entries
+  size_t n_atoms{0};
+  for(size_t i = 0, n = atoms.size(); i < n; ++i){
+    if(whichGrid[i] >= 0){
+      n_atoms++;
+    }
+  }
+  out << n_atoms << "\n\n"; // xyz
+  
+  // Print coordinates and gradients
   for (unsigned i = 0, n = atoms.size(); i < n; ++i) {
+
+    // Skip invalid channel
+    if(whichGrid[i] < 0){
+      continue;
+    }
+
     out << sym[whichGrid[i]] << " ";
     out << atoms[i].x << " " << atoms[i].y << " " << atoms[i].z << " ";
     out << gradient[i].x << " " << gradient[i].y << " " << gradient[i].z;

--- a/scripts/makeflex.py
+++ b/scripts/makeflex.py
@@ -86,7 +86,6 @@ for ci in range(flex.numCoordsets()):  # Loop over different MODELs (MODEL/ENDMD
                     resatoms = flex[chain].select("resnum %d and not name H" % resnum)
                     w = which[(chain, resnum)]
                     which[(chain, resnum)] += 1  # update to next index
-                    #print(resnum, aname, chain, [atom for atom in resatoms])
                     atom = resatoms[w]  # this is the atom to replace this line with
                     c = atom.getCoordsets(ci)
                     line = PDBLINE % (
@@ -101,7 +100,7 @@ for ci in range(flex.numCoordsets()):  # Loop over different MODELs (MODEL/ENDMD
                         atype,
                     )
                 else:
-                    # Remove H atoms
+                    # Remove non-backbone H atoms in flexible residue
                     line = ""
 
         elif line.startswith("END"):


### PR DESCRIPTION
Fixed out of memory access when channel index is negative (by skipping the channel) and fixed size comparison in `getMappedLigandGradient`.