### PR TITLE
Added missing serialization for residue

### DIFF
--- a/gninasrc/lib/model.h
+++ b/gninasrc/lib/model.h
@@ -259,6 +259,12 @@ struct residue : public main_branch {
     residue(const main_branch& m)
         : main_branch(m) {
     }
+
+    friend class boost::serialization::access;
+    template<class Archive>
+    void serialize(Archive& ar, const unsigned version) {
+      ar & boost::serialization::base_object<main_branch>(*this);
+    }
 };
 
 enum distance_type {


### PR DESCRIPTION
I think the serialization for `struct residue` in `model.h` was missing.