### PR TITLE
Write test output locally

### DIFF
--- a/test/gnina/test_min.py
+++ b/test/gnina/test_min.py
@@ -12,7 +12,7 @@ import re
 gnina = sys.argv[1]  # take path to gnina executable as only argument
 
 #single atoms
-outfile = '/tmp/test.sdf'
+outfile = 'test.sdf'
 def rmout():
     try:
         os.remove(outfile)
@@ -156,3 +156,5 @@ output=subprocess.check_output('%s  -r data/C8flat.xyz -l data/C8bent.sdf --cnn_
 #output should not be similar to receptor
 assert not are_similar('data/C8flat.xyz',outfile)
 assert validate_energies(outfile,output,0.7)
+
+rmout()


### PR DESCRIPTION
I had the test `gninamin` failing a few times with `Error: could not open "/tmp/test.sdf" for writing.`. Writing the file where `ctest` is run and deleting it afterwards seems to make this error disappear.