### PR TITLE
Compilation warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ if("${CMAKE_BUILD_TYPE}" STREQUAL "")
 endif()
 
 set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
-set(CMAKE_CXX_FLAGS "-Wno-deprecated-declarations")
+set(CMAKE_CXX_FLAGS "-Wno-deprecated-declarations -Wno-unknown-pragmas")
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 
 set(CMAKE_CUDA_SEPARABLE_COMPILATION ON)

--- a/caffe/include/caffe/syncedmem.hpp
+++ b/caffe/include/caffe/syncedmem.hpp
@@ -58,7 +58,7 @@ class SyncedMemory {
  public:
   SyncedMemory();
   explicit SyncedMemory(size_t size);
-  ~SyncedMemory();
+  ~SyncedMemory() noexcept(false);
   const void* cpu_data();
   void set_cpu_data(void* data);
   const void* gpu_data();

--- a/caffe/include/caffe/util/benchmark.hpp
+++ b/caffe/include/caffe/util/benchmark.hpp
@@ -10,7 +10,7 @@ namespace caffe {
 class Timer {
  public:
   Timer();
-  virtual ~Timer();
+  virtual ~Timer() noexcept(false);
   virtual void Start();
   virtual void Stop();
   virtual float MilliSeconds();

--- a/caffe/src/caffe/syncedmem.cpp
+++ b/caffe/src/caffe/syncedmem.cpp
@@ -23,7 +23,7 @@ SyncedMemory::SyncedMemory(size_t size)
 #endif
 }
 
-SyncedMemory::~SyncedMemory() {
+SyncedMemory::~SyncedMemory() noexcept(false) {
   check_device();
   if (cpu_ptr_ && own_cpu_data_) {
     CaffeFreeHost(cpu_ptr_, cpu_malloc_use_cuda_);

--- a/caffe/src/caffe/util/benchmark.cpp
+++ b/caffe/src/caffe/util/benchmark.cpp
@@ -12,7 +12,7 @@ Timer::Timer()
   Init();
 }
 
-Timer::~Timer() {
+Timer::~Timer() noexcept(false) {
   if (Caffe::mode() == Caffe::GPU) {
 #ifndef CPU_ONLY
     CUDA_CHECK(cudaEventDestroy(start_gpu_));


### PR DESCRIPTION
This PR should get rid of most compilation warnings left.

* Add `noexcept(false)` to `caffe` destructors that throw an exception (destructors are `noexcept` by default from C++11)
* Add `-Wno-unknown-pragmas` to avoid warnings coming from `libmolgrid`, but silenced in the latter.