### PR TITLE
Reset "which" dictionary for each model in makeflex.py

### DIFF
--- a/scripts/makeflex.py
+++ b/scripts/makeflex.py
@@ -66,9 +66,9 @@ def atype_perception(atype, aname):
     return atype.strip()
 
 for ci in range(flex.numCoordsets()):  # Loop over different MODELs (MODEL/ENDMDL)
-    which = defaultdict(int)
     out.write("MODEL %d\n" % ci)
     for line in open(rigidname):  # Read rigid receptor PDB file line-by-line
+        which = defaultdict(int)
         if line.startswith("ATOM"):
             # Chain, residue and atom informations
             chain = line[21]


### PR DESCRIPTION
If the PDB file defining the (rigid) receptor contains multiple models, the `which` dictionary needs to be reset for each model, otherwise there can be mismatches with previous entries.