### PR TITLE
Check number of models in original receptor

### DIFF
--- a/scripts/makeflex.py
+++ b/scripts/makeflex.py
@@ -24,6 +24,10 @@ rigidname = args.rigid
 flexname = args.flex
 outfile = args.out
 
+rigid = prody.parsePDB(rigidname)
+if rigid.numCoordsets() != 1:
+    raise ValueError(f"More than one model (MODEL/ENDMDL) for {rigidname} is not allowed.")
+
 out = open(outfile, "w")
 
 flex = prody.parsePDB(flexname)


### PR DESCRIPTION
The `makeflex.py` script now ensures that the original receptor PDB file only contains one models and fails with a clear error message otherwise. 

(Given that we are now loading the receptor, probably we should use this instead of looping again on the same file afterwards, but that should probably be done in a different PR).