### PR TITLE
Fix compilation issue with Protobuf > 3.11

### DIFF
--- a/caffe/src/caffe/util/io.cpp
+++ b/caffe/src/caffe/util/io.cpp
@@ -54,7 +54,11 @@ bool ReadProtoFromBinaryFile(const char* filename, Message* proto) {
   CHECK_NE(fd, -1) << "File not found: " << filename;
   ZeroCopyInputStream* raw_input = new FileInputStream(fd);
   CodedInputStream* coded_input = new CodedInputStream(raw_input);
+#if GOOGLE_PROTOBUF_VERSION >= 3006000
+  coded_input->SetTotalBytesLimit(kProtoReadBytesLimit);
+#else
   coded_input->SetTotalBytesLimit(kProtoReadBytesLimit, 536870912);
+#endif
 
   bool success = proto->ParseFromCodedStream(coded_input);
 


### PR DESCRIPTION
CodedInputStream::SetTotalBytesLimit() only takes 1 argument since at least Protobuf 3.6, and fails to compile with Protobuf > 3.11:

```
[  4%] Building CXX object caffe/src/caffe/CMakeFiles/caffe.dir/util/io.cpp.o
/dev/shm/gnina-1.0.2/caffe/src/caffe/util/io.cpp: In function ‘bool caffe::ReadProtoFromBinaryFile(const char*, google::protobuf::Message*)’:
/dev/shm/gnina-1.0.2/caffe/src/caffe/util/io.cpp:57:66: error: no matching function for call to ‘google::protobuf::io::CodedInputStream::SetTotalBytesLimit(const int&, int)’
   57 |   coded_input->SetTotalBytesLimit(kProtoReadBytesLimit, 536870912);
      |                                                                  ^
In file included from /dev/shm/gnina-1.0.2/caffe/src/caffe/util/io.cpp:2:
/share/software/user/open/protobuf/21.9/include/google/protobuf/io/coded_stream.h:384:8: note: candidate: ‘void google::protobuf::io::CodedInputStream::SetTotalBytesLimit(int)’
  384 |   void SetTotalBytesLimit(int total_bytes_limit);
      |        ^~~~~~~~~~~~~~~~~~
/share/software/user/open/protobuf/21.9/include/google/protobuf/io/coded_stream.h:384:8: note:   candidate expects 1 argument, 2 provided
make[2]: *** [caffe/src/caffe/CMakeFiles/caffe.dir/util/io.cpp.o] Error 1
make[1]: *** [caffe/src/caffe/CMakeFiles/caffe.dir/all] Error 2
make: *** [all] Error 2
```

See https://developers.google.com/protocol-buffers/docs/reference/cpp/google.protobuf.io.coded_stream#CodedInputStream.SetTotalBytesLimit.details