### PR TITLE
jsoncpp include

### DIFF
--- a/gninasrc/lib/torch_model.h
+++ b/gninasrc/lib/torch_model.h
@@ -9,7 +9,7 @@
 #define SRC_LIB_TORCH_MODEL_H_
 
 #include <iostream>
-#include <jsoncpp/json/json.h>
+#include <json/json.h>
 #include <libmolgrid/atom_typer.h>
 #include <libmolgrid/grid_maker.h>
 #include <torch/script.h>


### PR DESCRIPTION
When trying to build GNINA's master using a Spack-installed version of `jsoncpp` I incurred in issues with the include path. I think the `libjsoncpp-dev` headers in Ubuntu are pre-pended by the package name. 

It would be beneficial to use the standard include, and eventually use a symlink
```
sudo ln -s /usr/include/jsoncpp/json/ /usr/include/json
```
in Ubuntu containers etc.

Additionally, there is already a small inconsistency in the codebase, since the include in the `.cpp` file is different:
https://github.com/gnina/gnina/blob/97fa6bcc465d62b40d87ccc85d3c53e9921a7cc0/gninasrc/lib/torch_model.cpp#L10