### PR TITLE
[CMake] Allow to force external libraries and fix policy issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,9 @@ project (gnina C CXX CUDA)
 
 cmake_policy(SET CMP0104 NEW) 
 cmake_policy(SET CMP0135 NEW)
-cmake_policy(SET CMP0167 NEW) 
+if(POLICY CMP0167)
+  cmake_policy(SET CMP0167 NEW)
+endif()
 cmake_policy(SET CMP0094 NEW) #location first python finding
 cmake_policy(SET CMP0146 OLD) #too baked in
 
@@ -22,6 +24,7 @@ if("${CMAKE_BUILD_TYPE}" STREQUAL "")
 endif()
 
 option(BUILD_COVERAGE "Build with code coverage" OFF)
+option(GNINA_FORCE_EXTERNAL_LIBS "Use external libraries only" OFF)
 
 set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib;${CMAKE_INSTALL_PREFIX}/lib/gnina")
 set(CMAKE_CXX_FLAGS "-Wno-deprecated-declarations -Wno-unknown-pragmas")
@@ -68,7 +71,11 @@ find_package(Protobuf REQUIRED)
 # the commandline to build a mostly static (CUDA and standard system dependencies only) executable on my machine:
 # /usr/bin/c++ -Wno-deprecated-declarations -Wno-unknown-pragmas -D_GLIBCXX_USE_CXX11_ABI=1 -O3 -DNDEBUG -Wl,--disable-new-dtags CMakeFiles/gnina.dir/main/main.cpp.o CMakeFiles/gninalibobj.dir/version.cpp.o CMakeFiles/gninalibobj.dir/lib/atom_constants.cpp.o CMakeFiles/gninalibobj.dir/lib/bfgs.cu.o CMakeFiles/gninalibobj.dir/lib/box.cpp.o CMakeFiles/gninalibobj.dir/lib/builtinscoring.cpp.o CMakeFiles/gninalibobj.dir/lib/cache.cpp.o CMakeFiles/gninalibobj.dir/lib/cache_gpu.cpp.o CMakeFiles/gninalibobj.dir/lib/cnn_torch_scorer.cpp.o CMakeFiles/gninalibobj.dir/lib/coords.cpp.o CMakeFiles/gninalibobj.dir/lib/covinfo.cpp.o CMakeFiles/gninalibobj.dir/lib/custom_terms.cpp.o CMakeFiles/gninalibobj.dir/lib/dl_scorer.cpp.o CMakeFiles/gninalibobj.dir/lib/device_buffer.cpp.o CMakeFiles/gninalibobj.dir/lib/everything.cpp.o CMakeFiles/gninalibobj.dir/lib/flexinfo.cpp.o CMakeFiles/gninalibobj.dir/lib/GninaConverter.cpp.o CMakeFiles/gninalibobj.dir/lib/grid.cpp.o CMakeFiles/gninalibobj.dir/lib/grid_gpu.cu.o CMakeFiles/gninalibobj.dir/lib/model.cpp.o CMakeFiles/gninalibobj.dir/lib/molgetter.cpp.o CMakeFiles/gninalibobj.dir/lib/monte_carlo.cpp.o CMakeFiles/gninalibobj.dir/lib/mutate.cpp.o CMakeFiles/gninalibobj.dir/lib/my_pid.cpp.o CMakeFiles/gninalibobj.dir/lib/naive_non_cache.cpp.o CMakeFiles/gninalibobj.dir/lib/non_cache.cpp.o CMakeFiles/gninalibobj.dir/lib/non_cache_cnn.cpp.o CMakeFiles/gninalibobj.dir/lib/obmolopener.cpp.o CMakeFiles/gninalibobj.dir/lib/parallel_mc.cpp.o CMakeFiles/gninalibobj.dir/lib/parallel_progress.cpp.o CMakeFiles/gninalibobj.dir/lib/parse_pdbqt.cpp.o CMakeFiles/gninalibobj.dir/lib/pdb.cpp.o CMakeFiles/gninalibobj.dir/lib/PDBQTUtilities.cpp.o CMakeFiles/gninalibobj.dir/lib/quasi_newton.cpp.o CMakeFiles/gninalibobj.dir/lib/quaternion.cu.o CMakeFiles/gninalibobj.dir/lib/random.cpp.o CMakeFiles/gninalibobj.dir/lib/result_info.cpp.o CMakeFiles/gninalibobj.dir/lib/ssd.cpp.o CMakeFiles/gninalibobj.dir/lib/szv_grid.cpp.o CMakeFiles/gninalibobj.dir/lib/terms.cpp.o CMakeFiles/gninalibobj.dir/lib/weighted_terms.cpp.o CMakeFiles/gninalibobj.dir/lib/conf.cpp.o CMakeFiles/gninalibobj.dir/lib/conf_gpu.cu.o CMakeFiles/gninalibobj.dir/lib/gpucode.cu.o CMakeFiles/gninalibobj.dir/lib/model.cu.o CMakeFiles/gninalibobj.dir/lib/non_cache_gpu.cu.o CMakeFiles/gninalibobj.dir/lib/precalculate_gpu.cu.o CMakeFiles/gninalibobj.dir/lib/torch_model.cpp.o CMakeFiles/gninalibobj.dir/lib/tree_gpu.cu.o CMakeFiles/gninalibobj.dir/lib/user_opts.cpp.o CMakeFiles/gninalibobj.dir/torch_models.cpp.o CMakeFiles/gnina.dir/cmake_device_link.o -o ../bin/gnina   -L/usr/local/cuda-12.0/targets/x86_64-linux/lib/stubs  -L/usr/local/cuda-12.0/targets/x86_64-linux/lib  -Wl,-rpath,/usr/local/lib:/usr/local/cuda-12.0/lib64: all_default_to_default_1.3_1.o all_default_to_default_1.3_2.o all_default_to_default_1.3_3.o crossdock_default2018_1.3_1.o crossdock_default2018_1.3_2.o crossdock_default2018_1.3_3.o crossdock_default2018_1.3_4.o crossdock_default2018_1.3.o crossdock_default2018_1.o crossdock_default2018_2.o crossdock_default2018_3.o crossdock_default2018_4.o crossdock_default2018_KD_1.o crossdock_default2018_KD_2.o crossdock_default2018_KD_3.o crossdock_default2018_KD_4.o crossdock_default2018_KD_5.o crossdock_default2018.o default2017.o dense_1.3_1.o dense_1.3_2.o dense_1.3_3.o dense_1.3_4.o dense_1.3.o dense_1.3_PT_KD_1.o dense_1.3_PT_KD_2.o dense_1.3_PT_KD_3.o dense_1.3_PT_KD_4.o dense_1.3_PT_KD_def2018_1.o dense_1.3_PT_KD_def2018_2.o dense_1.3_PT_KD_def2018_3.o dense_1.3_PT_KD_def2018_4.o dense_1.3_PT_KD_def2018.o dense_1.3_PT_KD.o dense_1.o dense_2.o dense_3.o dense_4.o dense.o general_default2018_1.o general_default2018_2.o general_default2018_3.o general_default2018_4.o general_default2018_KD_1.o general_default2018_KD_2.o general_default2018_KD_3.o general_default2018_KD_4.o general_default2018_KD_5.o general_default2018.o redock_default2018_1.3_1.o redock_default2018_1.3_2.o redock_default2018_1.3_3.o redock_default2018_1.3_4.o redock_default2018_1.3.o redock_default2018_1.o redock_default2018_2.o redock_default2018_3.o redock_default2018_4.o redock_default2018_KD_1.o redock_default2018_KD_2.o redock_default2018_KD_3.o redock_default2018_KD_4.o redock_default2018_KD_5.o redock_default2018.o /usr/lib/x86_64-linux-gnu/libboost_program_options.a /usr/lib/x86_64-linux-gnu/libboost_system.a /usr/lib/x86_64-linux-gnu/libboost_iostreams.a /usr/lib/x86_64-linux-gnu/libboost_timer.a /usr/lib/x86_64-linux-gnu/libboost_thread.a /usr/lib/x86_64-linux-gnu/libboost_serialization.a /usr/lib/x86_64-linux-gnu/libboost_filesystem.a /usr/lib/x86_64-linux-gnu/libboost_date_time.a /usr/lib/x86_64-linux-gnu/libboost_regex.a /usr/lib/x86_64-linux-gnu/libboost_unit_test_framework.a /usr/local/lib/libopenbabel.a /usr/local/lib/libmolgrid.a -Wl,--whole-archive /usr/local/lib/libtorch.a -Wl,--no-whole-archive -Wl,--whole-archive /usr/local/lib/libtorch_cpu.a /usr/lib/gcc/x86_64-linux-gnu/11/libgomp.a        -Wl,--no-whole-archive -Wl,--whole-archive /usr/local/lib/libtorch_cuda.a -Wl,--no-whole-archive -Wl,--whole-archive -L/usr/local/cuda-12.0/lib64 -lcudart -lcusparse -lcufft -lnvToolsExt -lcurand -lcublas -lcublasLt  -lcusolver /home/dkoes/git/pytorch/build-static/nccl/lib/libnccl_static.a /usr/local/lib/libc10_cuda.a -Wl,--no-whole-archive /usr/local/lib/libc10.a /usr/local/lib/libnnpack.a /lib/x86_64-linux-gnu/libnuma.a /usr/local/lib/libpytorch_qnnpack.a /usr/local/lib/libXNNPACK.a /usr/local/lib/libprotobuf-lite.a /usr/local/lib/libprotobuf.a /usr/local/lib/libprotoc.a /usr/local/lib/libfmt.a /usr/local/lib/libcpuinfo.a /usr/local/lib/libclog.a /usr/local/lib/libpthreadpool.a /usr/local/lib/libfbgemm.a /usr/local/lib/libdnnl.a /usr/local/lib/libdnnl.a /usr/local/lib/libsleef.a /usr/local/lib/libasmjit.a /usr/local/lib/libkineto.a /usr/local/cuda-12.0/lib64/libcupti_static.a -lnvToolsExt -lcudart_static -ldl /usr/lib/x86_64-linux-gnu/librt.a /usr/lib/x86_64-linux-gnu/libz.a /usr/lib/x86_64-linux-gnu/libboost_chrono.a /home/dkoes/git/pytorch/build-static/lib/libgloo.a /usr/local/lib/gnina/libgloo_cuda.a /usr/lib/x86_64-linux-gnu/libboost_atomic.a /usr/local/lib/libjsoncpp.a /home/dkoes/git/pytorch/build-static/lib/libonnx.a /home/dkoes/git/pytorch/build-static/lib/libonnx_proto.a /usr/lib/x86_64-linux-gnu/libopenblas.a /usr/lib/gcc/x86_64-linux-gnu/11/libgfortran.a /usr/lib/gcc/x86_64-linux-gnu/11/libquadmath.a -lcudadevrt -lcudart_static 
 
-find_package(Torch)
+if(GNINA_FORCE_EXTERNAL_LIBS)
+  find_package(Torch 2 REQUIRED)
+else()
+  find_package(Torch)
+endif()
 
 set(CMAKE_CUDA_ARCHITECTURES "all-major")
 
@@ -127,7 +134,12 @@ endif()
 
 
 #libmolgrid  
-find_package(libmolgrid)
+if(GNINA_FORCE_EXTERNAL_LIBS)
+  find_package(libmolgrid REQUIRED)
+else()
+  find_package(libmolgrid)
+endif()
+
 if(NOT LIBMOLGRID_LIBRARY)
  message("libmolgrid will be fetched from git")
  include(ExternalProject)


### PR DESCRIPTION
When working with a package manager, it is better to rely only on external dependencies (provided by the package manager itself), instead of having the build system download and install them.

This PR introduces a `GNINA_FORCE_EXTERNAL_LIBS` option, to avoid GNINA silently falling back to automatic installation if something is not right, thus preventing GNINA from automatically installing `torch` and `libmolgrid`.

The PR also check for policy `CMP0167`. I was getting
```
  >> 3    CMake Error at CMakeLists.txt:7 (cmake_policy):
     4      Policy "CMP0167" is not known to this version of CMake.
```
with CMake `3.27`.

With this PR I was able to successfully build the latest commit (including #280) with CUDA `12.6` and PyTorch `2.4.1` using Spack.