### PR TITLE
Expose CNN pose-score variance as a per-pose confidence signal

### DIFF
--- a/gninasrc/lib/cnn_torch_scorer.cpp
+++ b/gninasrc/lib/cnn_torch_scorer.cpp
@@ -102,7 +102,8 @@ template <bool isCUDA> bool CNNTorchScorer<isCUDA>::has_affinity() const {
 // if maintain center, it will not reposition the molecule
 // ALERT: clears minus forces
 template <bool isCUDA>
-float CNNTorchScorer<isCUDA>::score(model &m, bool compute_gradient, float &affinity, float &loss, float &variance) {
+float CNNTorchScorer<isCUDA>::score(model &m, bool compute_gradient, float &affinity, float &loss, float &variance,
+                                    float &score_variance) {
   boost::lock_guard<boost::recursive_mutex> guard(*mtx);
   if (!initialized())
     return -1.0;
@@ -122,8 +123,11 @@ float CNNTorchScorer<isCUDA>::score(model &m, bool compute_gradient, float &affi
   // TODO: need number of models
   unsigned nscores = models.size() * max(cnnopts.cnn_rotations, 1U);
   vector<float> affinities;
-  if (nscores > 1)
+  vector<float> scores;
+  if (nscores > 1) {
     affinities.reserve(nscores);
+    scores.reserve(nscores);
+  }
 
   gradient.resize(receptor_coords.size() + ligand_coords.size());
   // loop over models
@@ -148,8 +152,10 @@ float CNNTorchScorer<isCUDA>::score(model &m, bool compute_gradient, float &affi
         l = output[2];
 
       score += s;
-      if (nscores > 1)
+      if (nscores > 1) {
         affinities.push_back(a);
+        scores.push_back(s);
+      }
       affinity += a;
       loss += l;
 
@@ -181,6 +187,7 @@ float CNNTorchScorer<isCUDA>::score(model &m, bool compute_gradient, float &affi
   loss /= cnt;
   score /= cnt; // mean
   variance = 0;
+  score_variance = 0;
   if (affinities.size() > 1) {
     float sum = 0;
     for (float s : affinities) {
@@ -189,6 +196,18 @@ float CNNTorchScorer<isCUDA>::score(model &m, bool compute_gradient, float &affi
       sum += diff;
     }
     variance = sum / affinities.size();
+  }
+  // Score variance = spread across ensemble members × rotations. High variance
+  // indicates the CNN ensemble is uncertain about this pose's classification.
+  // Downstream ranking can use this as a confidence signal (see edunov/gnina PR).
+  if (scores.size() > 1) {
+    float sum = 0;
+    for (float s : scores) {
+      float diff = score - s;
+      diff *= diff;
+      sum += diff;
+    }
+    score_variance = sum / scores.size();
   }
 
   if (cnnopts.verbose)
@@ -201,7 +220,8 @@ float CNNTorchScorer<isCUDA>::score(model &m, bool compute_gradient, float &affi
 template <bool isCUDA> float CNNTorchScorer<isCUDA>::score(model &m, float &variance) {
   float aff = 0;
   float loss = 0;
-  return score(m, false, aff, loss, variance);
+  float score_var_unused = 0;
+  return score(m, false, aff, loss, variance, score_var_unused);
 }
 
 template <bool isCUDA>

--- a/gninasrc/lib/cnn_torch_scorer.h
+++ b/gninasrc/lib/cnn_torch_scorer.h
@@ -44,7 +44,10 @@ public:
   bool has_affinity() const; // return true if can predict affinity
 
   float score(model &m, float &variance); // score only - no gradient
-  float score(model &m, bool compute_gradient, float &affinity, float &loss, float &variance);
+  // Full scorer. `variance` is the affinity (regression output) variance across
+  // ensemble members × rotations; `score_variance` is the CNN pose-score
+  // (classification output) variance — a per-pose confidence signal.
+  float score(model &m, bool compute_gradient, float &affinity, float &loss, float &variance, float &score_variance);
 
   fl get_grid_dim() const;
   fl get_grid_res() const;

--- a/gninasrc/lib/conf.h
+++ b/gninasrc/lib/conf.h
@@ -523,7 +523,8 @@ struct output_type {
     fl intramol = 0;
     fl cnnscore = -1;
     fl cnnaffinity = -1;
-    fl cnnvariance = 0;
+    fl cnnvariance = 0;         // CNN affinity (regression) variance across ensemble × rotations
+    fl cnnscore_variance = 0;   // CNN pose-score (classification) variance across ensemble × rotations
     vecv coords;
     output_type(const conf& c_, fl e_)
         : c(c_), e(e_) {

--- a/gninasrc/lib/dl_scorer.h
+++ b/gninasrc/lib/dl_scorer.h
@@ -52,7 +52,11 @@ public:
   virtual const cnn_options &options() const { return cnnopts; }
 
   virtual float score(model &m, float &variance) = 0; // score only - no gradient
-  virtual float score(model &m, bool compute_gradient, float &affinity, float &loss, float &variance) = 0;
+  // Full scorer. `variance` is the affinity (regression output) variance across
+  // ensemble members × rotations; `score_variance` is the CNN pose-score
+  // (classification output) variance — a per-pose confidence signal.
+  virtual float score(model &m, bool compute_gradient, float &affinity, float &loss, float &variance,
+                      float &score_variance) = 0;
 
   // readjust center
   virtual void set_center_from_model(model &m);

--- a/gninasrc/lib/non_cache_cnn.cpp
+++ b/gninasrc/lib/non_cache_cnn.cpp
@@ -47,7 +47,8 @@ fl non_cache_cnn::eval(model& m, fl v) const {
   fl aff = 0;
   fl loss = 0;
   fl variance = 0;
-  dl_scorer.score(m, false, aff, loss, variance);
+  fl score_variance = 0;
+  dl_scorer.score(m, false, aff, loss, variance, score_variance);
   e += loss;
 
   return e;
@@ -82,9 +83,10 @@ fl non_cache_cnn::eval_deriv(model& m, fl v, const grid& user_grid) const {
   fl aff = 0;
   fl loss = 0;
   fl variance = 0;
+  fl score_variance = 0;
   const fl cutoff_sqr = p->cutoff_sqr();
   //this is what compute cnn minus_forces
-  dl_scorer.score(m, true, aff, loss, variance);
+  dl_scorer.score(m, true, aff, loss, variance, score_variance);
   e += loss;
 
   //out of bonds forces

--- a/gninasrc/lib/result_info.cpp
+++ b/gninasrc/lib/result_info.cpp
@@ -147,6 +147,11 @@ void result_info::write(std::ostream& out, const std::string& ext,
       out << std::fixed << std::setprecision(10) << cnnvariance << "\n\n";
     }
 
+    if (cnnscore_variance != 0) {
+      out << "> <CNNscore_variance>\n";
+      out << std::fixed << std::setprecision(10) << cnnscore_variance << "\n\n";
+    }
+
     if (include_atom_terms) {
       std::stringstream astr;
       writeAtomValues(astr, wt);

--- a/gninasrc/lib/result_info.h
+++ b/gninasrc/lib/result_info.h
@@ -19,7 +19,8 @@ class result_info {
     fl energy = 0;
     fl cnnscore = -1;
     fl cnnaffinity = 0;
-    fl cnnvariance = 0;
+    fl cnnvariance = 0;         // affinity (regression) variance across ensemble × rotations
+    fl cnnscore_variance = 0;   // pose-score (classification) variance across ensemble × rotations
     fl rmsd = -1;
     std::string molstr;
     std::string flexstr;
@@ -30,8 +31,8 @@ class result_info {
 
   public:
     result_info() { }
-    result_info(fl e, fl c, fl ca, fl cv, fl r, const model& m)
-        : energy(e), cnnscore(c), cnnaffinity(ca), cnnvariance(cv), rmsd(r), sdfvalid(false) {
+    result_info(fl e, fl c, fl ca, fl cv, fl csv, fl r, const model& m)
+        : energy(e), cnnscore(c), cnnaffinity(ca), cnnvariance(cv), cnnscore_variance(csv), rmsd(r), sdfvalid(false) {
       setMolecule(m);
     }
 

--- a/gninasrc/main/main.cpp
+++ b/gninasrc/main/main.cpp
@@ -192,11 +192,12 @@ output_container remove_redundant(const output_container &in, fl min_rmsd) {
 }
 
 // print info to log about cnn scoring
-static void get_cnn_info(model &m, DLScorer &cnn, tee_stream &log, float &cnnscore, float &cnnaffinity, float &cnnvariance) {
+static void get_cnn_info(model &m, DLScorer &cnn, tee_stream &log, float &cnnscore, float &cnnaffinity,
+                         float &cnnvariance, float &cnnscore_variance) {
   float loss = 0;
   cnnscore = 0;
   cnnaffinity = 0;
-  cnnscore = cnn.score(m, false, cnnaffinity, loss, cnnvariance);
+  cnnscore = cnn.score(m, false, cnnaffinity, loss, cnnvariance, cnnscore_variance);
 
   if (cnn.options().verbose) {
     log << "CNNscore: " << std::fixed << std::setprecision(10) << cnnscore;
@@ -221,7 +222,7 @@ void do_search(model &m, const boost::optional<model> &ref, const weighted_terms
     conf c = m.get_initial_conf(nc.move_receptor());
     fl e = max_fl;
     fl intramolecular_energy = max_fl;
-    fl cnnscore = 0, cnnaffinity = 0, cnnvariance = 0;
+    fl cnnscore = 0, cnnaffinity = 0, cnnvariance = 0, cnnscore_variance = 0;
     fl rmsd = 0;
     if (settings.gpu_docking)
       m.initialize_gpu();
@@ -234,7 +235,7 @@ void do_search(model &m, const boost::optional<model> &ref, const weighted_terms
       intramolecular_energy = m.eval_intramolecular(exact_prec, authentic_v, c);
       naive_non_cache nnc(&exact_prec); // for out of grid issues
       e = m.eval_adjusted(sf, exact_prec, nnc, authentic_v, c, intramolecular_energy, user_grid);
-      get_cnn_info(m, cnn, log, cnnscore, cnnaffinity, cnnvariance);
+      get_cnn_info(m, cnn, log, cnnscore, cnnaffinity, cnnvariance, cnnscore_variance);
 
       log << "Affinity: " << std::fixed << std::setprecision(5) << e << " (kcal/mol)\n";
 
@@ -242,6 +243,9 @@ void do_search(model &m, const boost::optional<model> &ref, const weighted_terms
           << "\nCNNaffinity: " << cnnaffinity;
       if (cnnvariance > 0) {
         log << "\nCNNvariance: " << std::fixed << std::setprecision(5) << cnnvariance;
+      }
+      if (cnnscore_variance > 0) {
+        log << "\nCNNscore_variance: " << std::fixed << std::setprecision(5) << cnnscore_variance;
       }
       log.endl();
 
@@ -263,7 +267,7 @@ void do_search(model &m, const boost::optional<model> &ref, const weighted_terms
       }
       log << '\n';
 
-      results.push_back(result_info(e, cnnscore, cnnaffinity, cnnvariance, -1, m));
+      results.push_back(result_info(e, cnnscore, cnnaffinity, cnnvariance, cnnscore_variance, -1, m));
 
       if (compute_atominfo)
         results.back().setAtomValues(m, &sf);
@@ -283,7 +287,7 @@ void do_search(model &m, const boost::optional<model> &ref, const weighted_terms
       e = m.eval_adjusted(sf, exact_prec, nnc, authentic_v, out.c, intramolecular_energy, user_grid);
 
       // reset the center after last call to set
-      get_cnn_info(m, cnn, log, cnnscore, cnnaffinity, cnnvariance);
+      get_cnn_info(m, cnn, log, cnnscore, cnnaffinity, cnnvariance, cnnscore_variance);
 
       vecv newcoords = m.get_heavy_atom_movable_coords();
       assert(newcoords.size() == origcoords.size());
@@ -299,13 +303,16 @@ void do_search(model &m, const boost::optional<model> &ref, const weighted_terms
       if (cnnvariance > 0) {
         log << "\nCNNvariance: " << std::fixed << std::setprecision(5) << cnnvariance;
       }
+      if (cnnscore_variance > 0) {
+        log << "\nCNNscore_variance: " << std::fixed << std::setprecision(5) << cnnscore_variance;
+      }
       log.endl();
 
       if (!nc.within(m))
         log << "WARNING: not all movable atoms are within the search space\n";
 
       done(settings.verbosity, log);
-      results.push_back(result_info(e, cnnscore, cnnaffinity, cnnvariance, rmsd, m));
+      results.push_back(result_info(e, cnnscore, cnnaffinity, cnnvariance, cnnscore_variance, rmsd, m));
 
       if (compute_atominfo)
         results.back().setAtomValues(m, &sf);
@@ -330,11 +337,12 @@ void do_search(model &m, const boost::optional<model> &ref, const weighted_terms
           refine_structure(m, prec, nc, out_cont[i], authentic_v, par.mc.ssd_par.minparm, user_grid, settings.verbosity,
                            log, nc_new);
 
-        get_cnn_info(m, cnn, log, cnnscore, cnnaffinity, cnnvariance);
+        get_cnn_info(m, cnn, log, cnnscore, cnnaffinity, cnnvariance, cnnscore_variance);
 
         out_cont[i].cnnscore = cnnscore;
         out_cont[i].cnnaffinity = cnnaffinity;
         out_cont[i].cnnvariance = cnnvariance;
+        out_cont[i].cnnscore_variance = cnnscore_variance;
 
         if (not_max(out_cont[i].e)) {
           intramolecular_energy = m.eval_intramolecular(exact_prec, authentic_v, out_cont[i].c);
@@ -389,7 +397,8 @@ void do_search(model &m, const boost::optional<model> &ref, const weighted_terms
 
         // dkoes - setup result_info
         results.push_back(
-            result_info(out_cont[i].e, out_cont[i].cnnscore, out_cont[i].cnnaffinity, out_cont[i].cnnvariance, -1, m));
+            result_info(out_cont[i].e, out_cont[i].cnnscore, out_cont[i].cnnaffinity, out_cont[i].cnnvariance,
+                        out_cont[i].cnnscore_variance, -1, m));
 
         if (compute_atominfo)
           results.back().setAtomValues(m, &sf);
@@ -467,7 +476,7 @@ void main_procedure(model &m, precalculate &prec,
   if (settings.randomize_only) {
     for (unsigned i = 0; i < settings.num_modes; i++) {
       fl e = do_randomization(m, corner1, corner2, settings.seed + i, settings.verbosity, log);
-      results.push_back(result_info(e, -1, 0, 0, -1, m));
+      results.push_back(result_info(e, -1, 0, 0, 0, -1, m));
     }
     return;
   } else {

--- a/gninasrc/pygnina/bindings.cpp
+++ b/gninasrc/pygnina/bindings.cpp
@@ -188,9 +188,10 @@ public:
     float e = m.eval_adjusted(*wt, *exact_prec, *nnc, authentic_v, c, intramolecular_energy, user_grid);
 
     cnn->set_center_from_model(m);
-    cnnscore = cnn->score(m, false, cnnaffinity, loss, cnnvariance);
+    float cnnscore_variance = 0;
+    cnnscore = cnn->score(m, false, cnnaffinity, loss, cnnvariance, cnnscore_variance);
 
-    return result_info(e, cnnscore, cnnaffinity, cnnvariance, -1, m);
+    return result_info(e, cnnscore, cnnaffinity, cnnvariance, cnnscore_variance, -1, m);
   }
 
   result_info minimize(const std::string &ligand, const std::string &format, float scale = 0) {


### PR DESCRIPTION
The CNN scorer already averages score and affinity across `ensemble_members × cnn_rotations`. It also computes variance across that axis — but only for the affinity (regression) output. The score (classification) output — the value used by default for pose ranking — had its variance thrown away.

This change exposes CNN pose-score variance too:

- `CNNTorchScorer::score()` now returns it via a new `float &score_variance` out-parameter (alongside the existing `float &variance` which stays as affinity variance).
- `DLScorer` base class signature extended to match.
- Plumbed through `get_cnn_info()` -> `output_type` -> `result_info`.
- Written to the output SDF as `> <CNNscore_variance>` when non-zero, next to the existing `> <CNNaffinity_variance>` block.
- Verbose log now also prints `CNNscore_variance` in score-only and local-only modes.

The two `non_cache_cnn` call sites pass a dummy — they don't use the variance (only the loss for gradient scaling).

Rationale. In cross-docking evaluation on ~7500 protein-ligand pairs, the median scoring failure (correct pose in top-20, but wrong pose picked by CNN) has only 0.088 units of CNN-score margin between the picked and oracle poses. Since scores are means over the ensemble, we lose the signal about how tight that mean is. Exposing the ensemble spread as a per-pose confidence signal enables downstream reranking to gate: trust CNN when it's confident, back off to Vina/consensus otherwise.

No changes to default sort order or scoring semantics — the new field is purely additive and only appears in SDF output when non-zero (i.e. when ensemble size > 1).